### PR TITLE
use neotraverse as a drop in replacement of traverse to reduce bundle size

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var traverse = require('traverse')
+var traverse = require('neotraverse/legacy')
 var isSecret = require('is-secret')
 
 module.exports = function (redacted) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "is-secret": "^1.0.0",
-    "traverse": "^0.6.6"
+    "neotraverse": "^0.6.8"
   },
   "devDependencies": {
     "clone": "^2.0.0",


### PR DESCRIPTION
The current build use traverse to traverse through the object, however, traverse includes unnecessary polyfills which are no longer required, in order to improve the bundle size, neotraverse/legacy is used as a drop-in replacement as it provides same functionality as traverse while preserving es5 support and achieve much smaller bundle size.

**Before**

![Dependencies_for_redact_secrets_1_0_0_dependencies](https://github.com/user-attachments/assets/a0da85ee-eb10-4c18-adf6-db07916bb9b2)

**After**

<img width="455" alt="image" src="https://github.com/user-attachments/assets/18b07500-01a2-4adb-ac10-45c5b9d8fb88">
